### PR TITLE
7 cmod rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ A highly portable version of DDR/Stepmania for Mac/Unix terminals to play on the
 - Tap, hold, roll, and mine notes
 - Semi-compliant SM file format parser
 - Dynamic BPM changes (XMod)
+- Constant speed rendering (CMod)
 - Negative BPMs/stops (as defined by SM)
 - Minimal HUD
 - Various configs
-  - Scroll factor (aka relative spacing, thus "speed")
+  - Scroll factor (aka note speed)
   - Key mappings for n-K charts
   - Offset
 
@@ -23,6 +24,7 @@ Examples:
 ```
 python main.py "songs/V^3 (Hello World)" --scroll 0.75
 python main.py songs/Cloudless 1 --scroll 2 --keys "zxcv" --offset -0.002
+python main.py songs/Cloudless 1 --scroll 4.6667 --cmod
 ```
 
 You may need to enable input permissions during usage.
@@ -56,7 +58,7 @@ but the limited vertical resolution means this can only go so far (without a tal
 
 The limited resolution also means highly dense charts may not render quite as well on low scroll factors, as scroll=1 will round 16th+ notes to the same row while 12th-ish notes rely more on rhythm than visuals.
 
-There is no easy way to change the actual note speed in XMod without affecting spacing, due to the beat-relative position formula. Current solutions are adjusting the scroll factor, modifying the chart BPMs, or maybe injecting the vel factor to a custom format reader at load time.
+Due to y rounding, CMod may look jittery if the exact correct BPS is not used for scroll speed, where XMod would render at constant spacing for integer scrolls. For a constant 140 BPM song, scroll 2 on XMod equals 4.6667 on CMod (aka 140 / 60). Short of checking the file itself, the next best fix is simply to play at a sufficiently fast BPM.
 
 ## Resources Used
 A Hackaday blog post proposing a graph solution. No code given, but re-implemented the concept into an avg O(1) lookup:
@@ -84,14 +86,11 @@ Todo:
   - Notes should be coloured by their measure fraction and judgement state
   - Measure lines can be made a less intrusive colour
   - Judgement colour scheme (maybe emulate DDR colours or by early/lateness)
-- Constant speed via time-based rendering (CMod)
 - SSC format parser
   - Must support WARP
   - Both SM/SSC should parse the less common aliases
 - Custom format and its parser
   - Should allow true negative BPM as backrolling charts
-- Variable-width notes and note skins
-  - Probably requires a "canvas" buffer before cropped write
 - Hitsounds/claps/explosions
 - Fade out audio exit for graceful end
 - Live rewind/seek/loop section
@@ -112,3 +111,6 @@ Won't do (any time soon):
   - Best left to a separate repo
 - Chart search/navigator
   - Best left to a separate repo
+- Arrow heads and note skins
+  - Without a better framework for it, this is too difficult to implement well
+  - Not to mention, the limited vertical resolution means it usually doesn't fit nicely

--- a/flag.py
+++ b/flag.py
@@ -1,0 +1,5 @@
+class Flag:
+    # Hack to pass a bool flag by ref, used for threads
+    def __init__(self, init_state: bool):
+        self.state = init_state
+

--- a/game_field.py
+++ b/game_field.py
@@ -1,3 +1,4 @@
+import math
 import threading
 
 from judgement import Judgement
@@ -23,7 +24,10 @@ class GameField:
         # Clone, sort, and drop unhittable notes
         # We only clone the view, so that notes remain direct refs
         self.__note_columns = [
-            sorted(column, key=lambda x: x.timing)
+            sorted(
+                (x for x in column if not math.isinf(x.timing)),
+                key=lambda x: x.timing,
+            )
             for column in note_columns
         ]
 

--- a/main.py
+++ b/main.py
@@ -1,25 +1,14 @@
 import argparse
-import curses
-import math
 import os
-import sys
 import threading
 
-#import numpy as np
 import pynput
 from just_playback import Playback
 
-from bps_lines import BPSLines
+from flag import Flag
 from game_field import GameField
-from judgement import Judgement
-from note import Note, TapNote, HoldNote, RollNote, MineNote  # Renderer needs to break encapsulation
+from render import render
 from sm_reader import SMReader
-
-
-class Flag:
-    # Hack to pass a bool flag by ref, used for threads
-    def __init__(self, init_state: bool):
-        self.state = init_state
 
 
 class GameKeys:
@@ -169,291 +158,6 @@ def game_logic(
     keep_running.state = False
 
 
-# This is run on main thread to ensure safe shutdown on KeyboardInterrupt
-def render(
-    keep_running: Flag,
-    playback: Playback,
-    offset: float,
-    game_field: GameField,  # Thread-safe game state retrieval
-    bps_lines: BPSLines,  # Read-only note position lookup
-    note_columns: list[list[Note]],  # To be cloned raw notes
-    cmod_override: float | None = None,  # Swaps to cmod at a specific BPS
-    scroll: float = 1,  # Governs spacing (recommended no less than 1 on terminals)
-    min_tick_rate: float = 1.0/120.0,  # Some terminals are frame capped, so 60-120hz maybe
-):
-    # Handles all stdout writing
-
-    # NOTE:
-    # - game_field and raw notes (not the lists view) are live objs, so don't mutate
-    #     - We will however be reading them a lot to render prettily
-    #     - We will also break encapsulation a bit to analyse note type/props
-    # - bps_lines is also a ref, but it should be readonly at game time
-    # - TODO: cmod override changes sort and render algorthm, taking in a bps if so?
-
-    # First, clone and sort our local notes view
-    # In xmod, we always reflect chart order when rendering, rather than true hit time
-    if cmod_override is None:
-        render_columns = [
-            sorted(column, key=lambda x: x.beat)
-            for column in note_columns
-        ]
-
-    # But in cmod, we want to reflect the actual game logic by rendering at
-    # constant time and explicitly drop unhittable notes
-    else:
-        raise RuntimeError("Not implemented yet")  # TODO: Remove when ready
-        render_columns = [
-            sorted(
-                (x for x in column if not math.isinf(x.timing)
-            ), key=lambda x: x.timing)
-            for column in note_columns
-        ]
-
-    # We cache our sorted column positions to reduce search to avg O(1) per frame
-    # We will move up our cursors when the note is fully offscreen, and search the on-screen window
-    render_cursors = [0] * len(note_columns)
-
-    # Similarly, we can also cache our BPS lookups because of this linear search direction
-    bps_cursor = 0
-
-    # Other static vars
-    hit_line_y = 4  # Offset from screen edge
-    spacing = 8 * scroll  # Tuned to create a 8 char beat spacing at scroll 1
-    # Due to the limited resolution of a (vertical) terminal, I would not suggest <8 per full beat
-    
-    # TODO: Set up colours
-    # grey for dropped/missed holds
-    # orange for 4ths, blue for 8ths, green for all others (for now)
-    # red and white for hit displays
-    # Consider doing a slight shade for gentle beat flashes
-    # Mines could use red on a small sprite
-
-    # For the lack of a threaded curses wrapper, teardown errors manually
-    try:
-        # Prep terminal
-        stdscr = curses.initscr()
-        curses.noecho()  # Prevent stdin affecting console
-        #stdscr.nodelay(True)  # Non-blocking stdin on getch()  # NOTE: Will only use in ANSI version
-        stdscr.keypad(True)  # Consume arrows to prevent weird behaviours
-        #print("\x1b[?7l")  # Disable line wrap (truncates)  # TODO: check if this even works for curses
-
-        # TODO: Ensure all threads are fully loaded before starting
-        stdscr.addstr(0, 0, "loading")
-        stdscr.refresh()
-        event = threading.Event()
-        #event.wait(1)
-
-        while keep_running.state:
-            # If the user resizes, prefer to drop the frame rather than crash
-            try:
-                # Clear last frame
-                stdscr.erase()  # Presumably an optimised but maybe imperfect clear?
-
-                # Grab latest game states (other than notes)
-                judgement_counts, last_judgement, nps, accuracy = game_field.get_metrics()  # TODO: Will render summary counts later
-                song_time = playback.curr_pos + offset if playback.active else offset
-
-                # Calculate frame-specific vars
-                song_beat, bps_cursor = bps_lines.beat_at_time(
-                    song_time,
-                    last_line_index=bps_cursor,
-                    allow_stop=True,
-                    allow_warp=True,
-                )
-                r, c = stdscr.getmaxyx()
-
-                # Render hit line
-                stdscr.addstr(hit_line_y, 0, "-" * c)
-                
-                # NOTE: Assuming upscroll, 5 char width columns, no col spacing
-
-                # Render HUD (11x20)
-                # TODO: Move to right of game
-                # TODO: Colour?
-                stdscr.addnstr(10, 40, f"MARVELOUS: {judgement_counts[Judgement.MARVELOUS]}", 20)
-                stdscr.addnstr(11, 40, f"  PERFECT: {judgement_counts[Judgement.PERFECT]}", 20)
-                stdscr.addnstr(12, 40, f"    GREAT: {judgement_counts[Judgement.GREAT]}", 20)
-                stdscr.addnstr(13, 40, f"     GOOD: {judgement_counts[Judgement.GOOD]}", 20)
-                stdscr.addnstr(14, 40, f"      BOO: {judgement_counts[Judgement.BOO]}", 20)
-                stdscr.addnstr(15, 40, f"     MISS: {judgement_counts[Judgement.MISS]}", 20)
-                stdscr.addnstr(16, 40, f"       OK: {judgement_counts[Judgement.OK]}", 20)
-                stdscr.addnstr(17, 40, f"       NG: {judgement_counts[Judgement.NG]}", 20)
-
-                stdscr.addnstr(19, 40, f"      NPS: {nps}", 20)
-                stdscr.addnstr(20, 40, f" Accuracy: {accuracy*1000:.2f}ms", 20)
-
-                # Render measure/beat lines
-                i = 0
-                measure_beat = (4 - song_beat % 4) // 1
-                beat_offset = 1 - song_beat % 1
-                beat_y = round(spacing * (beat_offset + i)) + hit_line_y
-                while beat_y < r - 1:
-                    if i % 4 == measure_beat:
-                        stdscr.addstr(beat_y, 0, "-----" * len(render_columns))
-                    else:
-                        stdscr.addstr(beat_y, 0, "  -  " * len(render_columns))
-                    i += 1
-                    beat_y = round(spacing * (beat_offset + i)) + hit_line_y
-
-                # Render all on-screen notes
-                for col_i, column in enumerate(note_columns):
-                    # Notes now store their own hit state
-                    # gamefield here is only required from the summary info (which we will leave until later)
-
-                    # Now render every note in the column
-                    # A note column is fully rendered once it goes offscreen (due to sort) or exhausted
-                    note_x = col_i * 5
-                    note_i = render_cursors[col_i]  # Start from last cache
-                    first_renderable = None  # Determines where to move the cache to next loop, accounting for long notes
-                    on_screen = True
-                    
-                    while on_screen and note_i < len(column):
-                        note = column[note_i]
-                        note_y = -round(spacing * (song_beat - note.beat)) + hit_line_y
-                        note_judgement = note.judgement  # Snapshot
-
-                        # Note hasn't arrived yet, so column is fully rendered
-                        if note_y >= r-1:
-                            on_screen = False
-
-                        # Special case: Keep long notes rendered until fully past
-                        elif isinstance(note, HoldNote):
-                            tail_y = -round(spacing * (song_beat - note.tail_beat)) + hit_line_y
-
-                            # Still on field, so keep cursor at most here
-                            if note_y < r-1 and tail_y >= 0 and note_judgement != Judgement.OK:
-                                if first_renderable is None:
-                                    first_renderable = note_i
-
-                                # Render the body first (with user feedback)
-                                body_i = max(note_y, 0)
-                                max_tail_y = min(tail_y, r-1)
-                                if note_judgement is not None:
-                                    note_str = " - "  # Drop/miss
-                                elif (song_time - note.last_held) < 0.05:
-                                    # 50ms should work fine unless game polls roughly <1/20?
-                                    note_str = "|||"
-                                else:
-                                    note_str = " | "
-
-                                while body_i < max_tail_y:
-                                    stdscr.addstr(body_i, note_x + 1, note_str)
-                                    body_i += 1
-
-                                # Then render the head and body if on screen
-                                if max_tail_y == tail_y:
-                                    stdscr.addstr(max_tail_y, note_x, "[===]")
-
-                                if note_y >= 0:
-                                    stdscr.addstr(note_y, note_x, "[===]")
-
-                        elif isinstance(note, RollNote):
-                            tail_y = -round(spacing * (song_beat - note.tail_beat)) + hit_line_y
-
-                            # Still on field, so keep cursor at most here
-                            if note_y < r-1 and tail_y >= 0 and note_judgement != Judgement.OK:
-                                if first_renderable is None:
-                                    first_renderable = note_i
-
-                                # Render the body first (with user feedback)
-                                body_i = max(note_y, 0)
-                                max_tail_y = min(tail_y, r-1)
-                                if note_judgement is not None:
-                                    note_str = " - "  # Drop/miss
-                                elif (song_time - note.last_held) <= 0.15:
-                                    note_str = "<W>"
-                                else:
-                                    note_str = " W "
-
-                                while body_i < max_tail_y:
-                                    stdscr.addstr(body_i, note_x + 1, note_str)
-                                    body_i += 1
-
-                                # Then render the head and body if on screen
-                                if max_tail_y == tail_y:
-                                    stdscr.addstr(max_tail_y, note_x, "<<->>")
-
-                                if note_y >= 0:
-                                    stdscr.addstr(note_y, note_x, "<<->>")
-
-                        # On-field and still pending scoring or a miss
-                        elif note_y >= 0 and (
-                            note_judgement is None or
-                            note_judgement in (Judgement.MISS, Judgement.NG)
-                        ):
-                            if first_renderable is None:
-                                first_renderable = note_i
-
-                            #note_miss = note_judgement is not None
-                            # TODO: grey out misses later
-                            # Or maybe grey out purely relative to hitline?
-                            # Not sure if BOO will be included?
-
-                            # TODO: need to render a sprite based on type and column
-                            # Some sort of get_note_skin(note) np char patch cropped and pasted to a canvas
-                            # as a mini factory injected with a noteskin, this will analyse the note's key/subtype/states to render the whole note
-                            # Presumably, it will also need to return the new coords for corner-wise pasting
-
-                            # For now, just render the head/tail as single rows
-                            # TODO: Paint notes
-                            note_str = "  X  " if isinstance(note, MineNote) else "[===]"
-                            stdscr.addstr(note_y, note_x, note_str)
-
-                        # Do not render successful notes nor those gone past
-
-                        note_i += 1
-                    # End rendering this whole column
-
-                    # Update the render cache
-                    if first_renderable is not None:
-                        render_cursors[col_i] = first_renderable
-                    elif note_i >= len(column):
-                        # Column is exhausted, ensure it always skips future loops
-                        render_cursors[col_i] = note_i
-                    # Otherwise there might still be more notes offscreen, so do nothing
-                        
-                # End rendering all note columns
-
-                # Render recent judgement
-                # Per tradition, render over game area
-                stdscr.addnstr(10, 5, f"{last_judgement}"[10:].center(10), 20)
-
-                if playback.active and not playback.playing:
-                    stdscr.addstr(11, 7, "PAUSED")
-
-                # TODO: Once we implement complex note skins, move to this buffered array approach
-                # Paint to a temporary canvas to minimise bounds checking before every write
-                # To be on the safe side, reserve the last col for newline char
-                #c, r = curses.getmaxyx()
-                #canvas = np.full((r, c), " ", dtype="|S1")  # ASCII char array
-                #canvas[c-1]
-                # np nd-slicing makes cropping marginally easier than list[str] and pasting much easier
-
-                # Finally, crop to terminal
-
-                stdscr.move(r-1, c-1)
-                stdscr.refresh()
-                event.wait(min_tick_rate)
-            except curses.error:
-                # Window overflow due to user resize or tiny window
-                pass  # Drop the frame and continue
-
-        # End of game loop
-        # Manually teardown curses before game exit
-        curses.nocbreak()
-        stdscr.keypad(False)
-        curses.echo()
-        curses.flushinp()  # Flush stdin so game exit doesn't dump junk to CLI
-        curses.endwin()
-
-    except:
-        # Try as best as possible to teardown safely (might not work)
-        curses.nocbreak()
-        stdscr.keypad(False)
-        curses.echo()
-        curses.flushinp()
-        curses.endwin()
-        raise
 
 
 def parse_argv() -> argparse.Namespace:
@@ -582,14 +286,12 @@ if __name__ == "__main__":
         keep_running.state = False
         game_thread.join()
         listener.stop()
-        curses.flushinp()
         raise
         
 
     # Teardown (indirectly triggered by keep_running flag)
     game_thread.join()
     listener.stop()
-    curses.flushinp()
 
     # Errors in listener seems to be hard to handle safely?
 

--- a/main.py
+++ b/main.py
@@ -158,8 +158,6 @@ def game_logic(
     keep_running.state = False
 
 
-
-
 def parse_argv() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -177,10 +175,16 @@ def parse_argv() -> argparse.Namespace:
         help="nth note data in the chart file to read",
     )
     parser.add_argument(
+        "--cmod",
+        dest="xmod",
+        action="store_false",
+        help="Switches to constant time rendering (ignores speed changes)"
+    )
+    parser.add_argument(
         "--scroll",
         type=float,
         default=1.0,
-        help="Multiplier affecting note spacing and apparent speed",
+        help="Multiplier affecting note spacing and thus speed",
     )
     parser.add_argument(
         "--keys",
@@ -226,7 +230,6 @@ if __name__ == "__main__":
     music_file = os.path.join(chart_dir, reader.read_music_path(file_path))
     offset = reader.read_offset(file_path) + args.offset
 
-    # TODO: allow nk depending on what mappings are found in config (or passed in?)
     if len(note_columns) != len(args.keys):
         raise ValueError(f"Key mapping mismatch. Chart uses {len(note_columns)} keys, but given keys have {len(args.keys)}.")
 
@@ -275,6 +278,7 @@ if __name__ == "__main__":
             game_field,
             bps_lines,
             note_columns,
+            xmod=args.xmod,
             scroll=args.scroll,
         )
     except KeyboardInterrupt:

--- a/render.py
+++ b/render.py
@@ -262,8 +262,9 @@ def render(
     else:
         render_columns = [
             sorted(
-                (x for x in column if not math.isinf(x.timing)
-            ), key=lambda x: x.timing)
+                (x for x in column if not math.isinf(x.timing)),
+                key=lambda x: x.timing,
+            )
             for column in note_columns
         ]
 

--- a/render.py
+++ b/render.py
@@ -1,0 +1,409 @@
+import curses
+import math
+import threading
+
+from just_playback import Playback
+
+from bps_lines import BPSLines
+from flag import Flag
+from game_field import GameField
+from judgement import Judgement
+from note import Note, TapNote, HoldNote, RollNote, MineNote  # Renderer needs to break encapsulation
+
+
+# Each build func returns the y, x, text, attr (int 0 == no attr, per 2s-compl bitfield)
+
+
+def build_hud(
+    judgement_counts: dict[Judgement, int],
+    nps: float,
+    accuracy: float,
+) -> list[tuple[int, int, str, int]]:
+    # Returns draw data for the side HUD
+    return [
+        (0, 0, f"MARVELOUS: {judgement_counts[Judgement.MARVELOUS]}", 0),
+        (1, 2, f"PERFECT: {judgement_counts[Judgement.PERFECT]}", 0),
+        (2, 4, f"GREAT: {judgement_counts[Judgement.GREAT]}", 0),
+        (3, 5, f"GOOD: {judgement_counts[Judgement.GOOD]}", 0),
+        (4, 6, f"BOO: {judgement_counts[Judgement.BOO]}", 0),
+        (5, 5, f"MISS: {judgement_counts[Judgement.MISS]}", 0),
+        (6, 7, f"OK: {judgement_counts[Judgement.OK]}", 0),
+        (7, 7, f"NG: {judgement_counts[Judgement.NG]}", 0),
+
+        (9, 6, f"NPS: {nps}", 0),
+        (10, 1, f" Accuracy: {accuracy*1000:.2f}ms", 0),
+    ]
+
+
+def build_field_xmod(
+    col_count: int,
+    hit_line_y: int,
+    max_y: int,
+    spacing: float,
+    song_beat: float,
+) -> list[tuple[int, int, str, int]]:
+    # Returns draw data for the hit line and measure lines
+    patches = []
+
+    # Render measure/beat lines, noting SM's 4/4 assumption
+    i = 0
+    strong_beat = (4 - song_beat % 4) // 1
+    beat_offset = 1 - song_beat % 1
+    line_y = round(spacing * beat_offset) + hit_line_y
+    while line_y < max_y:
+        if i % 4 == strong_beat:
+            patches.append((line_y, 0, "-----" * col_count, 0))
+        else:
+            patches.append((line_y, 0, "  -  " * col_count, 0))
+        i += 1
+        line_y = round(spacing * (beat_offset + i)) + hit_line_y
+
+    # Render hit line in front, regardless of rounding
+    patches.append((hit_line_y, 0, "-----" * col_count, 0))
+
+    return patches
+
+
+def build_field_cmod(
+    bps_cursor: int,
+    bps_lines: BPSLines,
+    col_count: int,
+    hit_line_y: int,
+    max_y: int,
+    spacing: float,
+    song_beat: float,
+    song_time: float,
+) -> list[tuple[int, int, str, int]]:
+    # Returns draw data for the hit line and measure lines
+    patches = []
+
+    i = int(song_beat // 1) + 1
+    line_time, _ = bps_lines.time_at_beat(
+        i,
+        last_line_index=bps_cursor,
+        allow_stop=True,
+        allow_warp=True,
+    )  # Still avg O(1), but gimmicky maps may loop more
+    # Ensure any out of range is safely ignored
+    line_y = float("inf") if math.isinf(line_time) else -round(spacing * (song_time - line_time)) + hit_line_y
+    while line_y < max_y:
+        if i % 4 == 0:
+            patches.append((line_y, 0, "-----" * col_count, 0))
+        else:
+            patches.append((line_y, 0, "  -  " * col_count, 0))
+        i += 1
+        line_time, _ = bps_lines.time_at_beat(
+            i,
+            last_line_index=bps_cursor,
+            allow_stop=True,
+            allow_warp=True,
+        )
+        line_y = float("inf") if math.isinf(line_time) else -round(spacing * (song_time - line_time)) + hit_line_y
+
+    # Render hit line above
+    patches.append((hit_line_y, 0, "-----" * col_count, 0))
+
+    return patches
+
+
+def build_notes(
+    max_y: int,
+    head_y_func,  # Callable
+    tail_y_func,  # Callable
+    render_columns: list[list[Note]],
+    render_cursors: list[int],
+    song_time: float,
+) -> list[tuple[int, int, str, int]]:
+    # Returns the draw data for notes
+    # The closures are a lazy way of swapping out pos funcs for x/cmod. You may blame past me...
+    # Mutates render_cursors
+
+    patches = []
+
+    for col_i, column in enumerate(render_columns):
+        # Starting from our cached start point, render notes until off-screen or exhausted
+        note_x = col_i * 5
+        note_i = render_cursors[col_i]  # Start from last cache
+        first_renderable = None  # Determines where to move the cache to next loop, accounting for long notes
+        on_screen = True
+        
+        while on_screen and note_i < len(column):
+            note = column[note_i]
+            note_y = head_y_func(note)
+            note_judgement = note.judgement  # Snapshot
+
+            # Note hasn't arrived yet, so column is fully rendered
+            if note_y >= max_y:
+                on_screen = False
+
+            # Special case: Keep long notes rendered until fully past
+            elif isinstance(note, HoldNote):
+                tail_y = tail_y_func(note)
+
+                # Still on field, so keep cursor at most here
+                if note_y < max_y and tail_y >= 0 and note_judgement != Judgement.OK:
+                    if first_renderable is None:
+                        first_renderable = note_i
+
+                    # Render the body first (with user feedback)
+                    body_i = max(note_y, 0)
+                    max_tail_y = min(tail_y, max_y)
+                    if note_judgement is not None:
+                        note_str = " - "  # Drop/miss
+                    elif (song_time - note.last_held) < 0.05:
+                        # 50ms should work fine unless game polls roughly <1/20?
+                        note_str = "|||"
+                    else:
+                        note_str = " | "
+
+                    while body_i < max_tail_y:
+                        patches.append((body_i, note_x + 1, note_str, 0))
+                        body_i += 1
+
+                    # Then render the head and body if on screen
+                    if max_tail_y == tail_y:
+                        patches.append((max_tail_y, note_x, "[===]", 0))
+
+                    if note_y >= 0:
+                        patches.append((note_y, note_x, "[===]", 0))
+
+            elif isinstance(note, RollNote):
+                tail_y = tail_pos_func
+
+                # Still on field, so keep cursor at most here
+                if note_y < max_y and tail_y >= 0 and note_judgement != Judgement.OK:
+                    if first_renderable is None:
+                        first_renderable = note_i
+
+                    # Render the body first (with user feedback)
+                    body_i = max(note_y, 0)
+                    max_tail_y = min(tail_y, max_y)
+                    if note_judgement is not None:
+                        note_str = " - "  # Drop/miss
+                    elif (song_time - note.last_held) <= 0.15:
+                        note_str = "<W>"
+                    else:
+                        note_str = " W "
+
+                    while body_i < max_tail_y:
+                        patches.append((body_i, note_x + 1, note_str, 0))
+                        body_i += 1
+
+                    # Then render the head and body if on screen
+                    if max_tail_y == tail_y:
+                        patches.append((max_tail_y, note_x, "<<->>", 0))
+
+                    if note_y >= 0:
+                        patches.append((note_y, note_x, "<<->>", 0))
+
+            # On-field and still pending scoring or a miss
+            elif note_y >= 0 and (
+                note_judgement is None or
+                note_judgement in (Judgement.MISS, Judgement.NG)
+            ):
+                if first_renderable is None:
+                    first_renderable = note_i
+
+                #note_miss = note_judgement is not None
+                # TODO: grey out misses later
+                # Or maybe grey out purely relative to hitline?
+                # Not sure if BOO will be included?
+
+                # For now, just render the head/tail as single rows
+                # TODO: Paint notes
+                note_str = "  X  " if isinstance(note, MineNote) else "[===]"
+                patches.append((note_y, note_x, note_str, 0))
+
+            # Do not render successful notes nor those gone past
+
+            note_i += 1
+        # End rendering this whole column
+
+        # Update the render cache
+        if first_renderable is not None:
+            render_cursors[col_i] = first_renderable
+        elif note_i >= len(column):
+            # Column is exhausted, ensure it always skips future loops
+            render_cursors[col_i] = note_i
+        # Otherwise there might still be more notes offscreen, so do nothing
+            
+    # End rendering all note columns
+    return patches
+
+
+def render(
+    keep_running: Flag,
+    playback: Playback,
+    offset: float,
+    game_field: GameField,  # Thread-safe game state retrieval
+    bps_lines: BPSLines,  # Read-only note position lookup
+    note_columns: list[list[Note]],  # To be cloned raw notes
+    xmod: bool = True,  # Swaps between dynamic BPS XMod and CMod
+    scroll: float = 1,  # Governs spacing (recommended no less than 1 on terminals)
+    min_tick_rate: float = 1.0/120.0,  # Some terminals are frame capped, so 60-120hz maybe
+):
+    # Handles all stdout writing
+
+    # NOTE: Do not mutate game_field, raw notes,. Some of these are purposely unthreaded.
+    # We will be break encapsulation a bit to analyse notes for detailed rendering
+
+    # if cmod, call the cmod variant of beat lines render and note formula, but reuse the rest
+
+    # First, clone and sort our local notes view
+    # In xmod, we always reflect chart order when rendering, rather than true hit time
+    if xmod:
+        render_columns = [
+            sorted(column, key=lambda x: x.beat)
+            for column in note_columns
+        ]
+
+    # But in cmod, we want to reflect the actual game logic by rendering at
+    # constant time and explicitly drop unhittable notes
+    else:
+        render_columns = [
+            sorted(
+                (x for x in column if not math.isinf(x.timing)
+            ), key=lambda x: x.timing)
+            for column in note_columns
+        ]
+
+    # Cache for O(1) lookups
+    render_cursors = [0] * len(note_columns)  # Due to sorted notes, remember pos for next frame
+    bps_cursor = 0  # BPS lookups are also forward-only
+    # As seen later, we only need to render notes until off-screen, hence tiny window
+
+    # Other static vars
+    hit_line_y = 4  # Offset from screen edge
+    spacing = 8 * scroll  # Tuned to create a 8 char beat spacing at scroll 1
+    # NOTE: CMod results in 8 chars per second at scroll 1, simulating 60BPM
+    # Due to the limited resolution of a (vertical) terminal, I would not suggest <8 per full beat
+    
+    # TODO: Set up colours
+    # grey for dropped/missed holds
+    # orange for 4ths, blue for 8ths, green for all others (for now)
+    # red and white for hit displays
+    # Consider doing a slight shade for gentle beat flashes
+    # Mines could use red on a small sprite
+
+    # must return colour info?
+
+    # For the lack of a threaded curses wrapper, teardown errors manually
+    try:
+        # Prep terminal
+        stdscr = curses.initscr()
+        curses.noecho()  # Prevent stdin affecting console
+        #stdscr.nodelay(True)  # Non-blocking stdin on getch()  # NOTE: Will only use in ANSI version
+        stdscr.keypad(True)  # Consume arrows to prevent weird behaviours
+        #print("\x1b[?7l")  # Disable line wrap (truncates)  # TODO: check if this even works for curses
+
+        # TODO: Ensure all threads are fully loaded before starting
+        stdscr.addstr(0, 0, "loading")
+        stdscr.refresh()
+        event = threading.Event()
+        #event.wait(1)
+
+        while keep_running.state:
+            # If the user resizes, prefer to drop the frame rather than crash
+            try:
+                # Clear last frame
+                stdscr.erase()  # Presumably an optimised but maybe imperfect clear?
+
+                # Snapshot live game states (other than notes)
+                judgement_counts, last_judgement, nps, accuracy = game_field.get_metrics()
+                song_time = playback.curr_pos + offset if playback.active else offset
+
+                # Calculate frame-specific vars
+                song_beat, bps_cursor = bps_lines.beat_at_time(
+                    song_time,
+                    last_line_index=bps_cursor,
+                    allow_stop=True,
+                    allow_warp=True,
+                )
+                r, c = stdscr.getmaxyx()
+                # game_offset_x = int((c - (len(render_columns) * 5)) // 2)  # TODO: centering stuff
+                # hud_offset_x = (c - game_offset_x) + int(len(render_columns) * 5 // 2)
+
+                # NOTE: Assuming upscroll, 5 char width columns, no col spacing
+
+                # Split out patch building, but assemble and finalise draw here
+                # This simplifies toggling features, transparency, position/constraints, etc
+                # As a side effect, the interface is clearer and uses way less nesting
+
+                # NOTE: Subwindows is too janky to be reliable atm, and panels still throws out of bounds
+                # Hence we are handling it manually like this
+
+                # Render HUD (enforce 11x20 BB and 10,40 offset)
+                # TODO: Move to right of game
+                # TODO: Colour?
+                hud_data = build_hud(judgement_counts, nps, accuracy)
+                for text_y, text_x, text, text_attr in hud_data[:11]:
+                    stdscr.addnstr(10 + text_y, 40 + text_x, text, 20, text_attr)
+                
+                # Render game underlay (offset later)
+                if xmod:
+                    field_data = build_field_xmod(len(render_columns), hit_line_y, r-1, spacing, song_beat)
+                else:
+                    field_data = build_field_cmod(bps_cursor, bps_lines, len(render_columns), hit_line_y, r-1, spacing, song_beat, song_time)
+                for text_y, text_x, text, text_attr in field_data:
+                    # TODO: Center game area
+                    stdscr.addstr(text_y, text_x, text, text_attr)
+
+                # Render all on-screen notes (offset later)
+                if xmod:
+                    # Inject closures to avoid ~100 lines of duplication
+                    note_data = build_notes(
+                        r-1,
+                        lambda note: -round(spacing * (song_beat - note.beat)) + hit_line_y,
+                        lambda note: -round(spacing * (song_beat - note.tail_beat)) + hit_line_y,
+                        render_columns,
+                        render_cursors,
+                        song_time
+                    )
+                else:
+                    note_data = build_notes(
+                        r-1,
+                        lambda note: -round(spacing * (song_time - note.timing)) + hit_line_y,
+                        lambda note: -round(spacing * (song_time - note.tail_timing)) + hit_line_y,
+                        render_columns,
+                        render_cursors,
+                        song_time
+                    )
+                for text_y, text_x, text, text_attr in note_data:
+                    stdscr.addstr(text_y, text_x, text, text_attr)
+
+                # Render overlay (judgement and pause state)
+                # Per tradition, render over game area
+                game_mid = int(len(render_columns) * 5 // 2)  # + game_offset_x
+                text = str(last_judgement)[10:]  # Exploit enum form
+                stdscr.addstr(10, max(0, game_mid - int(len(text) // 2)), text)
+
+                if playback.active and not playback.playing:
+                    stdscr.addstr(11, max(0, game_mid - 3), "PAUSED")
+
+                stdscr.move(r-1, c-1)
+                stdscr.refresh()
+                event.wait(min_tick_rate)
+            except curses.error:
+                # Window overflow due to user resize or tiny window
+                try:
+                    stdscr.addstr(0, 0, "Frame dropped:\nResizing or window too small")
+                except curses.error:
+                    # Too small to even write that? Give up and loop
+                    pass
+
+        # End of game loop
+        # Manually teardown curses before game exit
+        curses.nocbreak()
+        stdscr.keypad(False)
+        curses.echo()
+        curses.flushinp()  # Flush stdin so game exit doesn't dump junk to CLI
+        curses.endwin()
+
+    except:
+        # Try as best as possible to teardown safely (might not work)
+        curses.nocbreak()
+        stdscr.keypad(False)
+        curses.echo()
+        curses.flushinp()
+        curses.endwin()
+        raise


### PR DESCRIPTION
Closes #9 as it was necessary to modularise rendering a bit more to squeeze in cmod stuff cleanly-ish. Should hopefully make other features much easier to implement.

Also fixed some bugs, including left over items in maps with warps (forgot to filter unhittables on game_field side), and the an edge case crash with holds/rolls that end on a warp not being handled/corrected on read.